### PR TITLE
set-cookie

### DIFF
--- a/handler.lua
+++ b/handler.lua
@@ -76,7 +76,7 @@ function JwtClaimsHeadersHandler:access(conf)
     for _,claim_pattern in pairs(conf.claims_to_include) do      
       if string.match(claim_key, "^"..claim_pattern.."$") then
         req_set_header("X-"..claim_key, claim_value)
-        kong.response.add_header('Set-Cookie', '_logged_in=1; Max-Age=300; Secure;')
+        kong.response.add_header('Set-Cookie', 'unsafe_logged_in=1; Max-Age=300; Secure;')
       end
     end
   end

--- a/handler.lua
+++ b/handler.lua
@@ -71,12 +71,13 @@ function JwtClaimsHeadersHandler:access(conf)
     return responses.send_HTTP_INTERNAL_SERVER_ERROR()
   end
 
+  kong.response.add_header('Set-Cookie', 'unsafe_logged_in=1; Max-Age=300; Secure;')
+
   local claims = jwt.claims
   for claim_key,claim_value in pairs(claims) do
     for _,claim_pattern in pairs(conf.claims_to_include) do      
       if string.match(claim_key, "^"..claim_pattern.."$") then
         req_set_header("X-"..claim_key, claim_value)
-        kong.response.add_header('Set-Cookie', 'unsafe_logged_in=1; Max-Age=300; Secure;')
       end
     end
   end

--- a/handler.lua
+++ b/handler.lua
@@ -76,6 +76,7 @@ function JwtClaimsHeadersHandler:access(conf)
     for _,claim_pattern in pairs(conf.claims_to_include) do      
       if string.match(claim_key, "^"..claim_pattern.."$") then
         req_set_header("X-"..claim_key, claim_value)
+        kong.response.add_header('Set-Cookie', '_logged_in=1; Max-Age=300; Secure;')
       end
     end
   end


### PR DESCRIPTION
@ludov04 first idea for setting a cookie for https://datacamp.atlassian.net/browse/INF-148

If we send a set cookie for all valid jwt it will keep it valid, seems safe to do it like this?

/cc @jaredsilver Ideas welcome on naming, I don't really like _logged_in as it's obvious and could easily be unknowingly misused by someone assuming is a secure/reliable way to check that the user is logged in, but don't want to go too obscure! 

Maybe `_pseudo_logged_in` ?!
