### PR TITLE
[INF-5012] Dual-emit X-user-id alongside X-user_id

### DIFF
--- a/kong-plugin-jwt-claims-headers-1.1-0.rockspec
+++ b/kong-plugin-jwt-claims-headers-1.1-0.rockspec
@@ -1,5 +1,5 @@
 package = "kong-plugin-jwt-claims-headers"
-version = "1.0-1"
+version = "1.1-0"
 source = {
   url = "TBD"
 }

--- a/spec/integration_spec.lua
+++ b/spec/integration_spec.lua
@@ -149,6 +149,8 @@ describe("jwt-claims-headers", function()
       assert.response(res).has.status(200)
       local user_id = assert.request(res).has.header("x-user-id")
       assert.equal("123", user_id)
+      local user_id_legacy = assert.request(res).has.header("x-user_id")
+      assert.equal("123", user_id_legacy)
       local iss = assert.request(res).has.header("x-iss")
       assert.equal(jwt_secret.key, iss)
 
@@ -173,6 +175,7 @@ describe("jwt-claims-headers", function()
       
       assert.response(res).has.status(200)
       assert.request(res).has.no.header("x-user-id")
+      assert.request(res).has.no.header("x-user_id")
       assert.request(res).has.no.header("x-iss")
       assert.request(res).has.no.header("x-nbf")
       assert.request(res).has.no.header("x-iat")
@@ -180,22 +183,24 @@ describe("jwt-claims-headers", function()
     end)
   end)
 
-  describe("x-user_id header", function() 
-    it("removes any x-user-id header if set on the request", function()
+  describe("x-user_id / x-user-id header", function()
+    it("removes any x-user_id and x-user-id header if set on the request", function()
       local res = assert(proxy_client:send {
         method  = "GET",
         path    = "/headers",
         headers = {
           ["Host"] = "test.com",
-          ["X-user_id"] = "456"
+          ["X-user_id"] = "456",
+          ["X-user-id"] = "789"
         },
       })
       -- Hack the X-Powered-By header so that the kong helpers know the request is coming from mockbin
       -- (https://github.com/Kong/kong/blob/8f36f3175c6a45be237d9ccd4ba227ff66e12d99/spec/helpers.lua#L1329)
       res.headers["X-Powered-By"] = "mock_upstream"
-      
+
       assert.response(res).has.status(200)
       assert.request(res).has.no.header("x-user-id")
+      assert.request(res).has.no.header("x-user_id")
     end)
   end)
 end)

--- a/src/handler.lua
+++ b/src/handler.lua
@@ -56,6 +56,7 @@ function JwtClaimsHeadersHandler:access(conf)
   JwtClaimsHeadersHandler.super.access(self)
   local continue_on_error = conf.continue_on_error
   req_clear_header("X-user_id")
+  req_clear_header("X-user-id")
 
   local token, err = retrieve_token(ngx.req, conf)
   
@@ -103,6 +104,9 @@ function JwtClaimsHeadersHandler:access(conf)
         ngx.ctx.jwt_claims[claim_key] = claim_value
         kong.ctx.shared.jwt_claims[claim_key] = claim_value
         req_set_header("X-"..claim_key, claim_value)
+        if claim_key == "user_id" then
+          req_set_header("X-user-id", claim_value)
+        end
       end
     end
   end


### PR DESCRIPTION
## Summary
- Set `X-user-id` (HTTP-conformant) alongside the legacy `X-user_id` whenever the JWT carries a `user_id` claim, and clear both forms on every request to prevent spoofing.
- Bumps rockspec to `1.1-0`.
- Updates integration spec to assert both headers reach the upstream and both are stripped from inbound requests.

Part of [INF-5012](https://datacamp.atlassian.net/browse/INF-5012) under epic [INF-5011](https://datacamp.atlassian.net/browse/INF-5011) — dual-write so consumers can migrate to the dash form before we deprecate the underscore form.

## Companion PR — gateway-side verification

End-to-end acceptance tests live in the gateway repo: **[datacamp-engineering/kong-gw#82](https://github.com/datacamp-engineering/kong-gw/pull/82)** (currently draft, will exit draft once this PR merges and the submodule SHA is re-bumped to the merge commit).

That PR adds [`acceptance_tests/specs/x-user-id.spec.ts`](https://github.com/datacamp-engineering/kong-gw/blob/inf-5012/dual-emit-x-user-id/acceptance_tests/specs/x-user-id.spec.ts), which sends a JWT through Kong to an `mendhak/http-https-echo` upstream and asserts:
1. Both `X-user-id` and `X-user_id` reach the upstream with identical values for a valid JWT.
2. Both are stripped from inbound requests when no JWT is presented.
3. Spoofed inbound copies are overridden by JWT-derived values.

All 32 acceptance tests pass locally on top of this branch (29 pre-existing + 3 new).

## Test plan
- [x] `make test` (busted spec) passes locally
- [x] End-to-end verification via kong-gw acceptance tests (see companion PR)
- [ ] Tag a release after merge so kong-gw can bump its submodule SHA

[INF-5012]: https://datacamp.atlassian.net/browse/INF-5012?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[INF-5011]: https://datacamp.atlassian.net/browse/INF-5011?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ