### PR TITLE
[INF-5012] Lowercase the new x-user-id header literal

### DIFF
--- a/spec/integration_spec.lua
+++ b/spec/integration_spec.lua
@@ -191,7 +191,7 @@ describe("jwt-claims-headers", function()
         headers = {
           ["Host"] = "test.com",
           ["X-user_id"] = "456",
-          ["X-user-id"] = "789"
+          ["x-user-id"] = "789"
         },
       })
       -- Hack the X-Powered-By header so that the kong helpers know the request is coming from mockbin

--- a/src/handler.lua
+++ b/src/handler.lua
@@ -56,7 +56,7 @@ function JwtClaimsHeadersHandler:access(conf)
   JwtClaimsHeadersHandler.super.access(self)
   local continue_on_error = conf.continue_on_error
   req_clear_header("X-user_id")
-  req_clear_header("X-user-id")
+  req_clear_header("x-user-id")
 
   local token, err = retrieve_token(ngx.req, conf)
   
@@ -105,7 +105,7 @@ function JwtClaimsHeadersHandler:access(conf)
         kong.ctx.shared.jwt_claims[claim_key] = claim_value
         req_set_header("X-"..claim_key, claim_value)
         if claim_key == "user_id" then
-          req_set_header("X-user-id", claim_value)
+          req_set_header("x-user-id", claim_value)
         end
       end
     end


### PR DESCRIPTION
## Summary
Follow-up to #8 — lowercases **only** the new `x-user-id` header literal that #8 introduced. Purely cosmetic / consistency-only.

The legacy `X-user_id` literal and the generic `X-<claim>` prefix are intentionally **left as-is** to keep the diff minimal and avoid touching pre-existing code that wasn't part of #8.

HTTP header names are case-insensitive on the wire — OpenResty/nginx normalises them internally — so this is **not a behavioural change**.

## Diff
```
- req_clear_header("X-user-id")
+ req_clear_header("x-user-id")

- req_set_header("X-user-id", claim_value)
+ req_set_header("x-user-id", claim_value)

# spec inbound test:
- ["X-user-id"] = "789"
+ ["x-user-id"] = "789"
```

## Test plan
- [x] Existing busted spec assertions still use lowercase keys (already worked because OpenResty normalises) — no assertion changes needed.
- [ ] CI green.