### PR TITLE
[COMM-9793] Remove unsafe_logged_in and unsafe_user_id cookies

### DIFF
--- a/src/handler.lua
+++ b/src/handler.lua
@@ -86,7 +86,6 @@ function JwtClaimsHeadersHandler:access(conf)
     })
   end
 
-  ngx.ctx.jwt_logged_in = true
   ngx.ctx.jwt_claims = {}
   kong.ctx.shared.jwt_claims = {}
   kong.ctx.shared.jwt_token = token
@@ -109,19 +108,6 @@ function JwtClaimsHeadersHandler:access(conf)
         end
       end
     end
-  end
-end
-
-function JwtClaimsHeadersHandler:header_filter(conf)
-  JwtClaimsHeadersHandler.super.header_filter(self)
-  local params = "Max-Age=15; Secure; Path=/;"
-
-  if ngx.ctx.jwt_logged_in then
-    kong.response.add_header('Set-Cookie', string.format('unsafe_logged_in=1; %s', params))
-  end
-
-  if ngx.ctx.jwt_claims and ngx.ctx.jwt_claims['user_id'] ~= nil then
-    kong.response.add_header('Set-Cookie', string.format('unsafe_user_id=%s; %s', ngx.ctx.jwt_claims['user_id'], params))
   end
 end
 


### PR DESCRIPTION
## Summary
- Removes the `header_filter` hook from `src/handler.lua` that emitted the `unsafe_logged_in` and `unsafe_user_id` cookies on every authenticated response.
- Drops the now-unused `ngx.ctx.jwt_logged_in` flag.

Additional context
https://datacamp.slack.com/archives/C03RWC7HP/p1778625743856509


🤖 Generated with [Claude Code](https://claude.com/claude-code)